### PR TITLE
Read the EntityLogicalName attribute on an entity for the logical name

### DIFF
--- a/MscrmTools.Shared/Link.cs
+++ b/MscrmTools.Shared/Link.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Client;
 using Microsoft.Xrm.Sdk.Query;
 using MscrmTools.FluentQueryExpressions.Helpers;
 using System;
 using System.Collections;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace MscrmTools.FluentQueryExpressions
 {
@@ -132,7 +134,7 @@ namespace MscrmTools.FluentQueryExpressions
         /// <param name="joinOperator">The join operator.</param>
         public Link(string toAttribute, string fromAttribute, JoinOperator joinOperator = JoinOperator.Inner)
         {
-            string toEntity = typeof(U).GetField("EntityLogicalName").GetRawConstantValue().ToString();
+            string toEntity = typeof(U).GetCustomAttribute<EntityLogicalNameAttribute>(true).LogicalName;
             ToEntity = toEntity;
             InnerLinkEntity = new LinkEntity(null, toEntity, fromAttribute, toAttribute, joinOperator)
             { EntityAlias = toEntity };
@@ -144,8 +146,8 @@ namespace MscrmTools.FluentQueryExpressions
         /// <param name="joinOperator">The join operator.</param>
         public Link(Expression<Func<T, object>> fromAttribute, Expression<Func<U, object>> toAttribute, JoinOperator joinOperator = JoinOperator.Inner)
         {
-            string fromEntity = typeof(T).GetField("EntityLogicalName").GetRawConstantValue().ToString();
-            string toEntity = typeof(U).GetField("EntityLogicalName").GetRawConstantValue().ToString();
+            string fromEntity = typeof(T).GetCustomAttribute<EntityLogicalNameAttribute>(true).LogicalName;
+            string toEntity = typeof(U).GetCustomAttribute<EntityLogicalNameAttribute>(true).LogicalName;
             ToEntity = toEntity;
             InnerLinkEntity = new LinkEntity(fromEntity, toEntity, AnonymousTypeHelper.GetAttributeName(fromAttribute), AnonymousTypeHelper.GetAttributeName(toAttribute), joinOperator)
             { EntityAlias = toEntity };
@@ -343,7 +345,7 @@ namespace MscrmTools.FluentQueryExpressions
         /// <returns>This <see cref="Link{T, U}"></see></returns>
         public Link<T, U> AddLink<V>(Link<U, V> link) where V : Entity
         {
-            string fromEntity = typeof(U).GetField("EntityLogicalName").GetRawConstantValue().ToString();
+            string fromEntity = typeof(U).GetCustomAttribute<EntityLogicalNameAttribute>(true).LogicalName;
 
             InnerLinkEntity.LinkEntities.Add(link.InnerLinkEntity);
 
@@ -360,10 +362,10 @@ namespace MscrmTools.FluentQueryExpressions
         /// <returns>This <see cref="Link{T, U}"></see></returns>
         public Link<T, U> AddLink<V>(Expression<Func<U, object>> sourceColumn, Expression<Func<V, object>> targetColumn, Func<Link<U, V>, Link<U, V>> link, JoinOperator jo = JoinOperator.Inner) where V : Entity
         {
-            string fromEntity = typeof(U).GetField("EntityLogicalName").GetRawConstantValue().ToString();
+            string fromEntity = typeof(U).GetCustomAttribute<EntityLogicalNameAttribute>(true).LogicalName;
             string fromAttr = AnonymousTypeHelper.GetAttributeName(sourceColumn);
             string toAttr = AnonymousTypeHelper.GetAttributeName(targetColumn);
-            string toEntity = typeof(V).GetField("EntityLogicalName").GetRawConstantValue().ToString();
+            string toEntity = typeof(V).GetCustomAttribute<EntityLogicalNameAttribute>(true).LogicalName;
 
             var le = new Link<U, V>(fromEntity, toEntity, fromAttr, toAttr, jo);
 
@@ -379,8 +381,8 @@ namespace MscrmTools.FluentQueryExpressions
         /// <returns>This <see cref="Link{T, U}"></see></returns>
         public Link<T, U> AddLink<V>(Func<Link<U, V>, Link<U, V>> link) where V : Entity
         {
-            string fromEntity = typeof(U).GetField("EntityLogicalName").GetRawConstantValue().ToString();
-            string toEntity = typeof(V).GetField("EntityLogicalName").GetRawConstantValue().ToString();
+            string fromEntity = typeof(U).GetCustomAttribute<EntityLogicalNameAttribute>(true).LogicalName;
+            string toEntity = typeof(V).GetCustomAttribute<EntityLogicalNameAttribute>(true).LogicalName;
 
             var le = new Link<U, V>(fromEntity, toEntity, null, null, JoinOperator.Inner);
 
@@ -398,10 +400,10 @@ namespace MscrmTools.FluentQueryExpressions
         /// <returns>This <see cref="Link{T, U}"></see></returns>
         public Link<T, U> AddLink<V>(Expression<Func<U, object>> sourceColumn, Expression<Func<V, object>> targetColumn, JoinOperator jo = JoinOperator.Inner) where V : Entity
         {
-            string fromEntity = typeof(U).GetField("EntityLogicalName").GetRawConstantValue().ToString();
+            string fromEntity = typeof(U).GetCustomAttribute<EntityLogicalNameAttribute>(true).LogicalName;
             string fromAttr = AnonymousTypeHelper.GetAttributeName(sourceColumn);
             string toAttr = AnonymousTypeHelper.GetAttributeName(targetColumn);
-            string toEntity = typeof(V).GetField("EntityLogicalName").GetRawConstantValue().ToString();
+            string toEntity = typeof(V).GetCustomAttribute<EntityLogicalNameAttribute>(true).LogicalName;
 
             var le = new Link<U, V>(fromEntity, toEntity, fromAttr, toAttr, jo);
 

--- a/MscrmTools.Shared/Query.cs
+++ b/MscrmTools.Shared/Query.cs
@@ -1,4 +1,5 @@
 using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Client;
 using Microsoft.Xrm.Sdk.Query;
 using MscrmTools.FluentQueryExpressions.Helpers;
 using System;
@@ -6,6 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace MscrmTools.FluentQueryExpressions
 {
@@ -20,9 +22,8 @@ namespace MscrmTools.FluentQueryExpressions
         /// Initialize a new instance of class <see cref="Query"/>
         /// </summary>
         /// <param name="table">Logical name of the table to query</param>
-        public Query(string table) : base()
+        public Query(string table) : base(table)
         {
-            QueryExpression = new QueryExpression(table);
         }
 
         #endregion Constructors
@@ -165,8 +166,17 @@ namespace MscrmTools.FluentQueryExpressions
         /// </summary>
         public Query()
         {
-            string entityLogicalName = typeof(T).GetField("EntityLogicalName")?.GetRawConstantValue().ToString();
+            string entityLogicalName = typeof(T).GetCustomAttribute<EntityLogicalNameAttribute>(true).LogicalName;
             QueryExpression = new QueryExpression(entityLogicalName);
+        }
+
+        /// <summary>
+        /// Initialize a new instance of class <see cref="Query{T}"/>
+        /// </summary>
+        /// <param name="table"></param>
+        public Query(string table)
+        {
+            QueryExpression = new QueryExpression(table);
         }
 
         #endregion Constructors
@@ -398,10 +408,10 @@ namespace MscrmTools.FluentQueryExpressions
         public Query<T> AddLink<U>(Expression<Func<T, object>> fromColumn, Expression<Func<U, object>> toColumn, Func<Link<T, U>, Link<T, U>> link, JoinOperator jo = JoinOperator.Inner)
             where U : Entity
         {
-            string fromEntity = typeof(T).GetField("EntityLogicalName").GetRawConstantValue().ToString();
+            string fromEntity = typeof(T).GetCustomAttribute<EntityLogicalNameAttribute>(true).LogicalName;
             string fromAttr = AnonymousTypeHelper.GetAttributeName(fromColumn);
             string toAttr = AnonymousTypeHelper.GetAttributeName(toColumn);
-            string toEntity = typeof(U).GetField("EntityLogicalName").GetRawConstantValue().ToString();
+            string toEntity = typeof(U).GetCustomAttribute<EntityLogicalNameAttribute>(true).LogicalName;
 
             var le = new Link<T, U>(fromEntity, toEntity, fromAttr, toAttr, jo);
 
@@ -421,8 +431,8 @@ namespace MscrmTools.FluentQueryExpressions
         public Query<T> AddLink<U>(Func<Link<T, U>, Link<T, U>> link)
            where U : Entity
         {
-            string fromEntity = typeof(T).GetField("EntityLogicalName").GetRawConstantValue().ToString();
-            string toEntity = typeof(U).GetField("EntityLogicalName").GetRawConstantValue().ToString();
+            string fromEntity = typeof(T).GetCustomAttribute<EntityLogicalNameAttribute>(true).LogicalName;
+            string toEntity = typeof(U).GetCustomAttribute<EntityLogicalNameAttribute>(true).LogicalName;
 
             var le = new Link<T, U>(fromEntity, toEntity, null, null, JoinOperator.Inner);
 
@@ -445,10 +455,10 @@ namespace MscrmTools.FluentQueryExpressions
             where U : Entity
 
         {
-            string fromEntity = typeof(T).GetField("EntityLogicalName").GetRawConstantValue().ToString();
+            string fromEntity = typeof(T).GetCustomAttribute<EntityLogicalNameAttribute>(true).LogicalName;
             string fromAttr = AnonymousTypeHelper.GetAttributeName(fromColumn);
             string toAttr = AnonymousTypeHelper.GetAttributeName(toColumn);
-            string toEntity = typeof(U).GetField("EntityLogicalName").GetRawConstantValue().ToString();
+            string toEntity = typeof(U).GetCustomAttribute<EntityLogicalNameAttribute>(true).LogicalName;
 
             var le = new Link<T, U>(fromEntity, toEntity, fromAttr, toAttr, jo);
 


### PR DESCRIPTION
Reading the `EntityLogicalName` member of an entity class is a magic that only works for classes written using early/late bound generators.

When writing an entity class by hand, it is not obvious that the class must have a member named `EntityLogicalName`.

Read the EntityLogicalName attribute on an entity for the logical name seems like a much saner implementation.

Verified that all passing tests still pass after this refactor.